### PR TITLE
docs: fix typos/grammar in example-apps/README.MD

### DIFF
--- a/example-apps/README.md
+++ b/example-apps/README.md
@@ -5,30 +5,32 @@ consume the data provided by the sensors.
 It's designed to be simple, so you can look around and grab the building blocks to 
 get going with your own ideas !
 
-- [websocket-client](websocket-client) is the simplest app, it subscribes to all events coming through the hackathon devices and log them on the console.
+- [websocket-client](websocket-client) is the simplest app, it subscribes to all events coming through the hackathon devices and logs them to the console.
 - [console](console) allows you to claim the device that you were handed out. It uses MQTT to stream
 the data coming from the claimed device.
-- The [dashboard](dashboard) aggregates the data coming from all the devices, using websocket. It then disaply a live dashboard.
+- The [dashboard](dashboard) aggregates the data coming from all the devices, using websocket. It then displays a live dashboard.
 
 # Consuming sensor data
 
-There are a few different way an application can obtain the data from a sensor: 
+There are a few different ways an application can obtain the data from a sensor:
+
     - subscribe to the event stream through the integration endpoints (MQTT or WebSocket)
     - get the events directly from the kafka topic
     - Query doppelgaenger (our digital kinda twin) to get the last known state of the device
 
-It's worth to note that sensors sends out "partial" updates, meaning that if only one button was pressed, the payload 
-will only contain the state of the button. Other sensors data may not be included in each update. 
+It's worth noting that sensors sends out "partial" updates, meaning that if only one button was pressed, the payload
+will only contain the state of that button. Other sensor data may not be included in each update.
 In order to get the aggregated data, you must query the doppelgaenger.
 
 ### Endpoints info
 
 #### WebSocket
 
-The websocket service is a simple endpoint that forward any events for an application into a websocket, as text. 
-
+The websocket service is a simple endpoint that forwards any events for an application into a websocket, as text.
+```
 host: ws-integration.sandbox.drogue.cloud
 port: 443
+```
 
 You can find more details on how to set up the connection [here](https://book.drogue.io/drogue-cloud/dev/user-guide/integration-ws.html)
 
@@ -38,9 +40,10 @@ The MQTT integration service allows to consume events from applications, just as
 back to devices.
 
 You can find more details on how to set up the connection [here](https://book.drogue.io/drogue-cloud/dev/user-guide/integration-mqtt.html)
-
+```
 host: mqtt-integration.sandbox.drogue.cloud
 port: 443
+```
 
 
 #### Doppelgaenger
@@ -49,7 +52,7 @@ The doppelgaenger is our spin on a digital twin service. It consolidates events 
 state that you can query. While the MQTT and WS services must be consumed in a "stream" fashion, the doppelgaenger is the 
 other way around : your application can query it whenever you want. 
 
-The REST API documentation for the doppelgaenger can be found [here](https://api-eclipsecon-2022.apps.sandbox.drogue.world/). It's worth to note here that `thing` should be the device name and the channel
+The REST API documentation for the doppelgaenger can be found [here](https://api-eclipsecon-2022.apps.sandbox.drogue.world/). It's worth noting here that `thing` should be the device name and the channel
 you want to pull data from. E.g `wolf/sensor` to get the sensor data.
 
 ## Authentication
@@ -66,9 +69,10 @@ or the dedicated REST command endpoint.
 
 To use the REST endpoint you need to POST to `https://$host/api/command/v1alpha1/apps/{application}/devices/{device}`, 
 with a body containing the payload of your command. 
-
+```
 host: https://api.sandbox.drogue.cloud
 port: 443
+```
 
 Drogue cloud will forward any json payload to a device.
 


### PR DESCRIPTION
This commit fixes a few typos/grammar, and also some formatting which were not being rendered as intended (I think).