### PR TITLE
Add meshd/lib .bak files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 /infra/target
+/infra/meshd/lib/**/*.bak
 node.json
 .vscode/


### PR DESCRIPTION
The motivation for this is that these files show up as untracked files:
```console
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	infra/meshd/lib/b67cef0dd1b2451fa54f8d34edba371b/node.json.bak
	infra/meshd/lib/fe8817cb1d0d4250b35de88939277c3a/node.json.bak
```