### PR TITLE
Add downloading of softdevice to flashsd.sh

### DIFF
--- a/firmware/flashsd.sh
+++ b/firmware/flashsd.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
+
+SD_VERSION=7.2.0
+
+# Download softdevice version from
+# https://github.com/NordicSemiconductor/nRF5-SDK-for-Mesh/tree/master/bin/softdevice
+curl -s https://raw.githubusercontent.com/NordicSemiconductor/nRF5-SDK-for-Mesh/master/bin/softdevice/s140_nrf52_${SD_VERSION}_softdevice.hex -o s140_nrf52_${SD_VERSION}_softdevice.hex
+
 probe-rs-cli erase --chip nRF52833_xxAA
-probe-rs-cli download s140_nrf52_7.3.0_softdevice.hex --format Hex --chip nRF52833_xxAA
+probe-rs-cli download s140_nrf52_${SD_VERSION}_softdevice.hex --format Hex --chip nRF52833_xxAA


### PR DESCRIPTION
This commit adds a curl command to download the softdevice binary to the flashsd script.

The version of the softdevice has been changed in this commit as well as I was not able to find 7.3.0 in
https://github.com/NordicSemiconductor/nRF5-SDK-for-Mesh/tree/master/bin/softdevice.

-----
I'm probably missing something here as I was not able to find the `7.3.0` version and also that the sd binaries are gitignored, but my initial thought was that it would be nice to have the sd used checked in for the hackaton just in case there are any network issues at the venue.