### PR TITLE
Use explicit imports for btmesh_nrf_software

### DIFF
--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -16,7 +16,7 @@ use adc::*;
 use battery::*;
 use btmesh_device::BluetoothMeshModel;
 use btmesh_macro::{device, element};
-use btmesh_nrf_softdevice::*;
+use btmesh_nrf_softdevice::{BluetoothMeshDriverConfig, Driver};
 use button::*;
 use core::future::Future;
 use display::*;


### PR DESCRIPTION
This commit add an explicit import/use for `btmesh_nrf_software::Driver`.

The motivation for this is that for someone new it might not be obvious which crate the `Driver` used in main comes from.