### PR TITLE
Add info log statement to firmware example

### DIFF
--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -19,6 +19,7 @@ use btmesh_macro::{device, element};
 use btmesh_nrf_softdevice::{BluetoothMeshDriverConfig, Driver};
 use button::*;
 use core::future::Future;
+use defmt::info;
 use display::*;
 use embassy_executor::Spawner;
 use embassy_nrf::interrupt;
@@ -45,6 +46,7 @@ use panic_reset as _;
 // Application main entry point. The spawner can be used to start async tasks.
 #[embassy_executor::main]
 async fn main(_s: Spawner) {
+    info!("EclipseCon 2022 Hackaton");
     // A board type to access peripherals on the microbit.
     let board = Microbit::new(config());
 


### PR DESCRIPTION
This commit adds a single info level log statement to the firmware example.

The motivation for this is that I think it might be helpful for users to add their own logging when exploring/developing during the hackaton, and with this change they won't have to think about importing `defmt::info`.