### PR TITLE
Update embassy-time and embassy-sync revisions in

### DIFF
--- a/infra/pre-provision/Cargo.toml
+++ b/infra/pre-provision/Cargo.toml
@@ -53,5 +53,5 @@ btmesh-driver = { git = "https://github.com/drogue-iot/btmesh.git", branch = "ma
 #btmesh-models = { path = "../../drogue-iot/btmesh/btmesh-models" }
 #btmesh-driver = { path = "../../drogue-iot/btmesh/btmesh-driver" }
 
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "3b58ac1bf86a2373e479e8e3cf92d2df7c29e00b" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "3b58ac1bf86a2373e479e8e3cf92d2df7c29e00b" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "b7d09442650d765562b25f9f27d654c2ef5e014a" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "b7d09442650d765562b25f9f27d654c2ef5e014a" }

--- a/infra/pre-provision/rust-toolchain.toml
+++ b/infra/pre-provision/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This commit updates the revision of embassy-time and embassy-sync in infra/pre-provision to fix the following compilation error:
```console
error[E0107]: this struct takes 1 generic argument but 2 generic arguments were supplied
  --> /.cargo/git/checkouts/btmesh-e14acedbce757b27/6840160/btmesh-device/src/lib.rs:34:27
   |
34 |     embassy_sync::signal::Signal<embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex, T>;
   |                           ^^^^^^ expected 1 generic argument                                 - help: remove this generic argument
   |
note: struct defined here, with 1 generic parameter: `T`
  --> /.cargo/git/checkouts/embassy-9312dcb0ed774b29/3b58ac1/embassy-sync/src/signal.rs:31:12
   |
31 | pub struct Signal<T> {
   |            ^^^^^^ -

For more information about this error, try `rustc --explain E0107`. error: could not compile `btmesh-device` due to previous error
```
The commit also adds a rust-toolchain.toml to configure nightly rustc as currently there a number of compilation errors like the following two:
```console
error[E0658]: generic associated types are unstable
   --> /.cargo/git/checkouts/embassy-9312dcb0ed774b29/b7d0944/embassy-sync/src/pipe.rs:450:9
    |
450 | /         type FlushFuture<'a> = impl Future<Output = Result<(), Self::Error>>
451 | |         where
452 | |             Self: 'a;
    | |_____________________^
    |
    = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable

error[E0658]: where clauses on associated types are unstable
   --> /.cargo/git/checkouts/embassy-9312dcb0ed774b29/b7d0944/embassy-sync/src/pipe.rs:450:9
    |
450 | /         type FlushFuture<'a> = impl Future<Output = Result<(), Self::Error>>
451 | |         where
452 | |             Self: 'a;
    | |_____________________^
    |
    = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable

   Compiling cargo_metadata v0.15.0
For more information about this error, try `rustc --explain E0658`.
error: could not compile `embassy-sync` due to 18 previous errors
warning: build failed, waiting for other jobs to finish...
```