### PR TITLE
Suppress unused variable warning in gateway.rs

### DIFF
--- a/infra/gateway/src/gateway.rs
+++ b/infra/gateway/src/gateway.rs
@@ -167,7 +167,7 @@ pub async fn run(
                                             };
                                             // TODO: Hmm, where to get this?
                                             let app_key = 0;
-                                            for i in 0..3 {
+                                            for _ in 0..3 {
                                                 match node.send(&raw, path.clone(), address, app_key).await {
                                                     Ok(_) => {
                                                         log::info!("Forwarded message to device");


### PR DESCRIPTION
Currently, the following compiler warnings is generated:
```console
$ cargo build --release
   Compiling eclipsecon-gateway v0.1.0 (/eclipsecon-2022-hackathon/infra/gateway)
warning: unused variable: `i`
   --> gateway/src/gateway.rs:170:49
    |
170 | ...                   for i in 0..3 {
    |                           ^ help: if this is intentional, prefix it with an underscore: `_i`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: `eclipsecon-gateway` (lib) generated 1 warning
```